### PR TITLE
issues getting going

### DIFF
--- a/.cfconfig.json
+++ b/.cfconfig.json
@@ -20,7 +20,7 @@
 			 "host":"${DB_HOST}",
 			 "dbdriver":"${DB_DRIVER}",
 			 "database":"${DB_DATABASE}",
-			 "dsn":"jdbc:mysql://{host}:{port}/{database}",
+			 "dsn": "jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}",
 			 "custom":"useUnicode=true&characterEncoding=UTF-8&useLegacyDatetimeCode=true&autoReconnect=true",
 			 "port":"${DB_PORT}",
 			 "class":"${DB_CLASS}",

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ENVIRONMENT=development
 # Database Information
 DB_CONNECTIONSTRING=jdbc:mysql://127.0.0.1:3306/pingcrm?useSSL=false&useUnicode=true&characterEncoding=UTF-8&serverTimezone=UTC&useLegacyDatetimeCode=true
 DB_CLASS=com.mysql.jdbc.Driver
+DB_BUNDLENAME=com.mysql.cj
 DB_DRIVER=MySQL
 DB_HOST=127.0.0.1
 DB_PORT=3306


### PR DESCRIPTION
Eric, 
 There were some hurdles running this which i don't recall existed the last time i tried to run this repo. So i think i addressed them.

Besides the code changes, for some reason, mysql didnt like timestamps to be nullable during migrations. I didn't fix them here because it might be an issue with qb or a MySQL specific issue. At least on my engine, it expects a default value even though it's nullable()

(MySQL 5.7.27)
Invalid default value for 'deleted_date'                                                                                                                                                                
2019_12_05_094253_create_organizations_table.cfc
CREATE TABLE `organizations` (`id` INTEGER UNSIGNED NOT NULL AUTO_INCREMENT, `account_id` INTEGER UNSIGNED NOT NULL, `name` VARCHAR(100) NOT NULL, `email` VARCHAR(50), `phone` VARCHAR(50), `address` VARCHAR(150), `city` VARCHAR(50), `region` VARCHAR(50), `country` VARCHAR(2), `postal_code` VARCHAR(25), `created_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `modified_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, **`deleted_date` TIMESTAMP**, CONSTRAINT `pk_organizations_id` PRIMARY KEY (`id`), CONSTRAINT `fk_organizations_account_id` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION)


